### PR TITLE
Add missing sign key for release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,10 +24,12 @@ android {
         debug {
             applicationIdSuffix '.debug'
             debuggable true
+            signingConfig signingConfigs.debug
         }
         release {
             debuggable false
             minifyEnabled true
+            signingConfig signingConfigs.debug
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
### Proposed changes
- Set release buildtype to use Debug sign key

### Sources
